### PR TITLE
Improve index and backlog scripts

### DIFF
--- a/backlogSelection.html
+++ b/backlogSelection.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
-  <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.3.0/material.min.js" defer></script>
+  <link rel="stylesheet" href="js/polyfill/dialog-polyfill.css" />
+  <script src="js/polyfill/dialog-polyfill.js" defer></script>
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
   <!-- Material Design icon and Montserrat fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -21,7 +25,7 @@
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
         <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
-              id="topleftlogo" /></a>
+              id="topleftlogo" alt="ScrumMaster logo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -102,9 +106,9 @@
       </dialog>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
-  <script src="js/selectBacklogTask.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/selectBacklogTask.js" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
-  <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.3.0/material.min.js" defer></script>
+  <link rel="stylesheet" href="js/polyfill/dialog-polyfill.css" />
+  <script src="js/polyfill/dialog-polyfill.js" defer></script>
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
   <!-- Material Design icon and Montserrat fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -21,7 +25,7 @@
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
         <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
-              id="topleftlogo" /></a>
+              id="topleftlogo" alt="ScrumMaster logo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -98,9 +102,9 @@
       </dialog>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
-  <script src="js/backlog.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/backlog.js" defer></script>
 </body>
 
 </html>

--- a/js/backlog.js
+++ b/js/backlog.js
@@ -17,12 +17,12 @@
  * filters tasks in product backlog by tag
  */
 function filter() {
-  let tagRef = document.getElementById("filterlist");
+  const tagRef = document.getElementById("filterlist");
   tagRef.addEventListener('change', _ => {
-    let tag = tagRef.value;
-    filteredTasks = tag == "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() == tag);
+    const tag = tagRef.value;
+    filteredTasks = tag === "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() === tag);
     displayTasks();
-  })
+  });
 
 }
 
@@ -170,15 +170,15 @@ function displayDialog(index) {
 let allTasks = [].concat(backlogTasks.criticalPriorityList, backlogTasks.highPriorityList, backlogTasks.mediumPriorityList, backlogTasks.lowPriorityList);
 let filteredTasks = allTasks;
 
-console.log(backlogTasks)
-
 // register dialog
-var dialog = document.querySelector('dialog');
+const dialog = document.querySelector('dialog');
 if (!dialog.showModal) {
   dialogPolyfill.registerDialog(dialog);
 }
 
 // Display tasks when page loads if backlogTasks is not empty
-filter();
-displayTasks();
+document.addEventListener('DOMContentLoaded', () => {
+  filter();
+  displayTasks();
+});
 

--- a/js/selectBacklogTask.js
+++ b/js/selectBacklogTask.js
@@ -19,12 +19,12 @@
  * filters tasks in product backlog by tag
  */
 function filter() {
-    let tagRef = document.getElementById("filterlist");
+    const tagRef = document.getElementById("filterlist");
     tagRef.addEventListener('change', _ => {
-        let tag = tagRef.value;
-        filteredTasks = tag == "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() == tag);
+        const tag = tagRef.value;
+        filteredTasks = tag === "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() === tag);
         displayTasks();
-    })
+    });
 
 }
 
@@ -252,7 +252,7 @@ let allTasks = [].concat(currentSprintTask, backlogTasks.criticalPriorityList, b
 
 let filteredTasks = allTasks;
 // register dialog
-var dialog = document.querySelector('dialog');
+const dialog = document.querySelector('dialog');
 if (!dialog.showModal) {
     dialogPolyfill.registerDialog(dialog);
 }
@@ -266,8 +266,10 @@ document.getElementById("startButton").addEventListener('click', _ => startSprin
 // confirms
 document.getElementById("saveButton").addEventListener('click', _ => {
     if (saveSelection()) window.location = "listOfSprints.html";
-})
+});
 // Display tasks when page loads if backlogTasks is not empty
-filter();
-displayTasks();
+document.addEventListener('DOMContentLoaded', () => {
+    filter();
+    displayTasks();
+});
 


### PR DESCRIPTION
## Summary
- improve HTML headers on main pages
- add alt text to page logos
- load scripts with `defer` and include dialog polyfill
- remove console output and register DOM loaded event in JavaScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f26c65b848331a54d5a25edaa0ad8