### PR TITLE
Improve backlog design

### DIFF
--- a/Template.HTML
+++ b/Template.HTML
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
@@ -19,7 +21,7 @@
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
-        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
               id="topleftlogo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
@@ -48,8 +50,8 @@
       <div class="mdl-grid"></div>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
 </body>
 
 </html>

--- a/addSprint.html
+++ b/addSprint.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -15,14 +17,14 @@
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/addTask.css">
 
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
 </head>
 
 <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>
@@ -79,8 +81,8 @@
             </div>
         </div>
     </main>
-    <script src="js/shared.js"></script>
-    <script src="js/addSprint.js"></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/addSprint.js" defer></script>
 </body>
 
 </html>

--- a/addTask.html
+++ b/addTask.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects">
 
   <!-- Material Design Lite -->
@@ -15,14 +17,14 @@
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/addTask.css">
 
-  <script src="js/config.js"></script>
+  <script src="js/config.js" defer></script>
 </head>
 
 <body>
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
-        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
               id="topleftlogo"></a> ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -156,8 +158,8 @@
       </div>
     </div>
   </main>
-  <script src="js/shared.js"></script>
-  <script src="js/addTask.js"></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/addTask.js" defer></script>
 </body>
 
 </html>

--- a/addTeam.html
+++ b/addTeam.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -15,14 +17,14 @@
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/addTask.css">
 
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
 </head>
 
 <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>
@@ -76,8 +78,8 @@
             </div>
         </div>
     </main>
-    <script src="js/shared.js"></script>
-    <script src="js/addTeam.js"></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/addTeam.js" defer></script>
 </body>
 
 </html>

--- a/analytics.html
+++ b/analytics.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
       content="A project management software for agile projects"
@@ -26,7 +28,7 @@
     <link rel="stylesheet" href="css/main.css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
   </head>
 
   <body>
@@ -35,7 +37,7 @@
         <div class="mdl-layout__header-row">
           <span class="mdl-layout-title" id="Montserrat"
             ><a href="index.html"
-              ><img src="img/ClockGears.jpeg" id="topleftlogo"
+              ><img src="img/ClockGears.jpeg" alt="ScrumMaster logo" id="topleftlogo"
             /></a>
             ScrumMASTER</span
           >
@@ -99,8 +101,8 @@
             padding: 10px;
           }
         </style>
-        <script src="js/shared.js"></script>
-        <script src="js/analytics.js"></script>
+        <script src="js/shared.js" defer></script>
+        <script src="js/analytics.js" defer></script>
 
         <div class="emptyBox">
           <h5 id="centre">How much member has worked per day</h5>

--- a/backlogSelection.html
+++ b/backlogSelection.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
-  <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.3.0/material.min.js" defer></script>
+  <link rel="stylesheet" href="js/polyfill/dialog-polyfill.css" />
+  <script src="js/polyfill/dialog-polyfill.js" defer></script>
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
   <!-- Material Design icon and Montserrat fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -21,7 +25,7 @@
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
         <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
-              id="topleftlogo" /></a>
+              id="topleftlogo" alt="ScrumMaster logo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -57,17 +61,18 @@
                 <option value="TESTING">Testing</option>
                 <option value="UI">UI</option>
               </select>
+              <label class="mdl-textfield__label" for="filterlist">Filter</label>
             </div>
           </div>
           <div class="mdl-cell mdl-cell--2-col">
             <a href="listofSprints.html">
-              <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect " id="saveButton">
-                Save & Return
+              <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect" id="saveButton">
+                <i class="material-icons">save</i>&nbsp;Save &amp; Return
               </button>
             </a>
             &nbsp;
-            <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect " id="startButton">
-              Start Sprint
+            <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect" id="startButton">
+              <i class="material-icons">play_arrow</i>&nbsp;Start Sprint
             </button>
           </div>
         </div>
@@ -102,9 +107,9 @@
       </dialog>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
-  <script src="js/selectBacklogTask.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/selectBacklogTask.js" defer></script>
 </body>
 
 </html>

--- a/bar.html
+++ b/bar.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
     <script src="js/analytics.js"></script>
     <body> 

--- a/burndown.html
+++ b/burndown.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -14,10 +16,10 @@
     <!-- CSS Links -->
     <link rel="stylesheet" href="css/main.css">
 
-    <script src="js/config.js"></script>
-    <script src="js/shared.js"></script>
-    <script src="js/Chart.js"></script>
-    <script src="js/burndownData.js"></script>
+    <script src="js/config.js" defer></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/Chart.js" defer></script>
+    <script src="js/burndownData.js" defer></script>
   
 </head>
 
@@ -25,7 +27,7 @@
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>

--- a/css/main.css
+++ b/css/main.css
@@ -13,9 +13,14 @@ button {
     font-family: 'Montserrat';
 }
 
+body {
+    background-color: #f5f5f5;
+    font-family: 'Montserrat', sans-serif;
+}
+
 .mdl-layout__content {
-    background-color: white;
-    font-family: 'Montserrat';
+    background-color: transparent;
+    font-family: 'Montserrat', sans-serif;
 }
 
 .mdl-grid {
@@ -86,7 +91,22 @@ button {
 }
 
 #black {
-    background-color: black;
+    background-color: #556b2f;
+    color: white;
+}
+
+.mdl-layout__drawer {
+    background-color: #4caf50;
+    color: white;
+}
+
+#drawer-nav a {
+    color: white;
+}
+
+.mdl-button--colored {
+    background-color: #4caf50;
+    color: white;
 }
 
 #myButton {
@@ -111,6 +131,23 @@ button {
 #taskcard {
     width: 320px;
     height: 320px;
+    background-color: #ffffff;
+    border-radius: 4px;
+}
+
+.task-card {
+    animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 #centre {

--- a/edit.html
+++ b/edit.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects">
 
   <!-- Material Design Lite -->
@@ -15,14 +17,14 @@
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/addTask.css">
 
-  <script src="js/config.js"></script>
+  <script src="js/config.js" defer></script>
 </head>
 
 <body>
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
-        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
               id="topleftlogo"></a> ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -136,8 +138,8 @@
       </div>
     </div>
   </main>
-  <script src="js/shared.js"></script>
-  <script src="js/edit.js"></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/edit.js" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
-  <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.3.0/material.min.js" defer></script>
+  <link rel="stylesheet" href="js/polyfill/dialog-polyfill.css" />
+  <script src="js/polyfill/dialog-polyfill.js" defer></script>
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
   <!-- Material Design icon and Montserrat fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -21,7 +25,7 @@
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
         <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
-              id="topleftlogo" /></a>
+              id="topleftlogo" alt="ScrumMaster logo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
         <div class="mdl-layout-spacer"></div>
@@ -57,12 +61,13 @@
                 <option value="TESTING">Testing</option>
                 <option value="UI">UI</option>
               </select>
+              <label class="mdl-textfield__label" for="filterlist">Filter</label>
             </div>
           </div>
           <div class="mdl-cell mdl-cell--2-col">
             <a href="addTask.html">
-              <button type="button" class="mdl-button mdl-js-button mdl-button--raised">
-                Add Task
+              <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">
+                <i class="material-icons">add</i>&nbsp;Add Task
               </button>
             </a>
           </div>
@@ -98,9 +103,9 @@
       </dialog>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
-  <script src="js/backlog.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/backlog.js" defer></script>
 </body>
 
 </html>

--- a/js/backlog.js
+++ b/js/backlog.js
@@ -17,12 +17,12 @@
  * filters tasks in product backlog by tag
  */
 function filter() {
-  let tagRef = document.getElementById("filterlist");
+  const tagRef = document.getElementById("filterlist");
   tagRef.addEventListener('change', _ => {
-    let tag = tagRef.value;
-    filteredTasks = tag == "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() == tag);
+    const tag = tagRef.value;
+    filteredTasks = tag === "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() === tag);
     displayTasks();
-  })
+  });
 
 }
 
@@ -46,6 +46,7 @@ function displayTasks() {
     let task = filteredTasks[i];
     let taskCard = document.createElement("div");
     taskCard.className = "mdl-cell mdl-cell--3-col";
+    taskCard.classList.add('task-card');
     let chip = task.priorityColour();
     // make this element clickable
     taskCard.setAttribute('data-index', i);
@@ -170,15 +171,15 @@ function displayDialog(index) {
 let allTasks = [].concat(backlogTasks.criticalPriorityList, backlogTasks.highPriorityList, backlogTasks.mediumPriorityList, backlogTasks.lowPriorityList);
 let filteredTasks = allTasks;
 
-console.log(backlogTasks)
-
 // register dialog
-var dialog = document.querySelector('dialog');
+const dialog = document.querySelector('dialog');
 if (!dialog.showModal) {
   dialogPolyfill.registerDialog(dialog);
 }
 
 // Display tasks when page loads if backlogTasks is not empty
-filter();
-displayTasks();
+document.addEventListener('DOMContentLoaded', () => {
+  filter();
+  displayTasks();
+});
 

--- a/js/selectBacklogTask.js
+++ b/js/selectBacklogTask.js
@@ -19,12 +19,12 @@
  * filters tasks in product backlog by tag
  */
 function filter() {
-    let tagRef = document.getElementById("filterlist");
+    const tagRef = document.getElementById("filterlist");
     tagRef.addEventListener('change', _ => {
-        let tag = tagRef.value;
-        filteredTasks = tag == "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() == tag);
+        const tag = tagRef.value;
+        filteredTasks = tag === "" ? allTasks : allTasks.filter(e => e.tag.toUpperCase() === tag);
         displayTasks();
-    })
+    });
 
 }
 
@@ -46,6 +46,7 @@ function displayTasks() {
         let task = filteredTasks[i];
         let taskCard = document.createElement("div");
         taskCard.className = "mdl-cell mdl-cell--3-col";
+        taskCard.classList.add('task-card');
         // make this element clickable
         taskCard.style.cursor = "pointer";
         taskCard.style.zIndex = 11;
@@ -252,7 +253,7 @@ let allTasks = [].concat(currentSprintTask, backlogTasks.criticalPriorityList, b
 
 let filteredTasks = allTasks;
 // register dialog
-var dialog = document.querySelector('dialog');
+const dialog = document.querySelector('dialog');
 if (!dialog.showModal) {
     dialogPolyfill.registerDialog(dialog);
 }
@@ -266,8 +267,10 @@ document.getElementById("startButton").addEventListener('click', _ => startSprin
 // confirms
 document.getElementById("saveButton").addEventListener('click', _ => {
     if (saveSelection()) window.location = "listOfSprints.html";
-})
+});
 // Display tasks when page loads if backlogTasks is not empty
-filter();
-displayTasks();
+document.addEventListener('DOMContentLoaded', () => {
+    filter();
+    displayTasks();
+});
 

--- a/listOfSprints.html
+++ b/listOfSprints.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -14,14 +16,14 @@
     <!-- CSS Links -->
     <link rel="stylesheet" href="css/main.css">
 
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
 </head>
 
 <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>
@@ -107,8 +109,8 @@
             </div>
         </main>
     </div>
-    <script src="js/shared.js"></script>
-    <script src="js/listOfSprints.js"></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/listOfSprints.js" defer></script>
 </body>
 
 </html>

--- a/listOfTeamMembers.html
+++ b/listOfTeamMembers.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -14,14 +16,14 @@
     <!-- CSS Links -->
     <link rel="stylesheet" href="css/main.css">
 
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
 </head>
 
 <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>
@@ -121,8 +123,8 @@
             </div>
         </main>
     </div>
-    <script src="js/shared.js"></script>
-    <script src="js/listOfTeamMembers.js"></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/listOfTeamMembers.js" defer></script>
 </body>
 
 </html>

--- a/sprintboard.HTML
+++ b/sprintboard.HTML
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="A project management software for agile projects" />
 
   <!-- Material Design Lite -->
-  <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.3.0/material.min.js" defer></script>
+  <link rel="stylesheet" href="js/polyfill/dialog-polyfill.css" />
+  <script src="js/polyfill/dialog-polyfill.js" defer></script>
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css" />
   <!-- Material Design icon and Montserrat fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -20,7 +24,7 @@
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <header class="mdl-layout__header" id="black">
       <div class="mdl-layout__header-row">
-        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+        <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
               id="topleftlogo" /></a>
           ScrumMASTER</span>
         <!-- Add spacer, to align page title to the right -->
@@ -115,9 +119,9 @@
       </dialog>
     </main>
   </div>
-  <script src="js/config.js"></script>
-  <script src="js/shared.js"></script>
-  <script src="js/sprintboard.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/shared.js" defer></script>
+  <script src="js/sprintboard.js" defer></script>
 </body>
 
 </html>

--- a/timelog.html
+++ b/timelog.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ScrumMASTER</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A project management software for agile projects">
 
     <!-- Material Design Lite -->
@@ -15,14 +17,14 @@
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/addTask.css">
 
-    <script src="js/config.js"></script>
+    <script src="js/config.js" defer></script>
 </head>
 
 <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <header class="mdl-layout__header" id="black">
             <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg"
+                <span class="mdl-layout-title" id="Montserrat"><a href="index.html"><img src="img/ClockGears.jpeg" alt="ScrumMaster logo"
                             id="topleftlogo"></a> ScrumMASTER</span>
                 <!-- Add spacer, to align page title to the right -->
                 <div class="mdl-layout-spacer"></div>
@@ -76,8 +78,8 @@
             </div>
         </div>
     </main>
-    <script src="js/shared.js"></script>
-    <script src="js/timelog.js"></script>
+    <script src="js/shared.js" defer></script>
+    <script src="js/timelog.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- restyle site colors in `main.css`
- add meta tags and alt text across HTML pages
- defer local scripts for reliable loading
- include dialog polyfill on sprint board

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f26c65b848331a54d5a25edaa0ad8